### PR TITLE
Image message coordinate systems

### DIFF
--- a/Source/igtlImageMessage.h
+++ b/Source/igtlImageMessage.h
@@ -61,8 +61,8 @@ public:
 public:
 
   enum {
-    COORDINATE_LPS,
-    COORDINATE_RAS
+    COORDINATE_RAS=1,
+    COORDINATE_LPS=2
   };
 
   enum {

--- a/Source/igtlImageMessage2.h
+++ b/Source/igtlImageMessage2.h
@@ -74,8 +74,8 @@ public:
 public:
 
   enum {
-    COORDINATE_LPS,
-    COORDINATE_RAS
+    COORDINATE_RAS=1,
+    COORDINATE_LPS=2
   };
 
   enum {


### PR DESCRIPTION
First commit: I added get and set methods to access the coordinate system value in the ImageMessage classes to make it easier to access this field since it is already being read and stored in the message object.

Second commit: I modified the enum in the ImageMessage classes that so that COORDINATE_LPS was defined as 2 as specified in the protocol; it had been set to 0 in the original enum. (Not sure if anyone was using this value and depending on it being 0...)
