### PR TITLE
BUG: use shutdown() instead of close() for sockets

### DIFF
--- a/Source/igtlSocket.cxx
+++ b/Source/igtlSocket.cxx
@@ -48,7 +48,7 @@
 #define WSA_VERSION MAKEWORD(1,1)
 #define igtlCloseSocketMacro(sock) (closesocket(sock))
 #else
-#define igtlCloseSocketMacro(sock) (close(sock))
+#define igtlCloseSocketMacro(sock) (shutdown(sock, 2))
 #endif
 
 namespace igtl


### PR DESCRIPTION
This keeps the handle open long enough to raise the closed event to
the client. See:
http://www.softlab.ntua.gr/facilities/documentation/unix/unix-socket-faq/unix-socket-faq-2.html#ss2.6

for https://github.com/openigtlink/OpenIGTLinkIF/issues/9
