### PR TITLE
BUG: Intializing pointer should not be in a loop

### DIFF
--- a/Source/igtlPolyDataMessage.cxx
+++ b/Source/igtlPolyDataMessage.cxx
@@ -805,9 +805,10 @@ int PolyDataMessage::UnpackBody()
   
   // Attributes
   this->m_Attributes.clear();
+  igtl_polydata_attribute * attr = info.attributes;
   for (unsigned int i = 0; i < info.header.nattributes; i ++)
     {
-    igtl_polydata_attribute * attr = info.attributes;
+    
 
     PolyDataAttribute::Pointer pda = PolyDataAttribute::New();
     if (pda.IsNotNull())


### PR DESCRIPTION
Pointer initialization should be done before the loop. Otherwise, the attr is reassigned at each iteration, attr++ do not have any affect, so that only the first attribute is pushed many times in the vector m_Attributes #34
