### PR TITLE
Add the MSG_NOSIGNAL flag to socket send calls to prevent application crash on disconnect on linux systems

### DIFF
--- a/Source/igtlSocket.cxx
+++ b/Source/igtlSocket.cxx
@@ -312,9 +312,16 @@ int Socket::Send(const void* data, int length)
 #if defined(_WIN32) && !defined(__CYGWIN__)
     flags = 0;
 #else
-    // disabling, since not present on SUN.
-    // flags = MSG_NOSIGNAL; //disable signal on Unix boxes.
+    // On unix boxes if the client disconnects and the server attempts
+    // to send data through the socket then the application crashes
+    // due to SIGPIPE signal. Disable the signal to prevent crash.
+  #ifndef __sun
+    flags = MSG_NOSIGNAL;
+  #else
+    // Signal is not present on SUN systems, the signal has
+    // to be managed at application level.
     flags = 0;
+  #endif
 #endif
     int n = send(this->m_SocketDescriptor, buffer+total, length-total, flags);
     if(n < 0)

--- a/Source/igtlSocket.h
+++ b/Source/igtlSocket.h
@@ -82,6 +82,8 @@ public:
  
   /// These methods send data over the socket.
   /// Returns 1 on success, 0 on error and raises vtkCommand::ErrorEvent.
+  /// SIGPIPE or other signal may be raised on systems (e.g., Sun Solaris) where
+  /// MSG_NOSIGNAL flag is not supported for the socket send method.
   int Send(const void* data, int length);
 
   /// Receive data from the socket.


### PR DESCRIPTION
Without the patch OpenIGTLink crashes when the peer disconnects and we try to send a message.

Tested on Windows (no flag need to be set) and on Linux (the patch fixes the crash).
