### PR TITLE
ENH: Reducing Slicer log spam by only outputting a connection failed message if requested

### DIFF
--- a/Source/igtlClientSocket.cxx
+++ b/Source/igtlClientSocket.cxx
@@ -41,7 +41,7 @@ ClientSocket::~ClientSocket()
 }
 
 //-----------------------------------------------------------------------------
-int ClientSocket::ConnectToServer(const char* hostName, int port, bool logErrorIfServerConnectionFailed /*= false*/)
+int ClientSocket::ConnectToServer(const char* hostName, int port, bool logErrorIfServerConnectionFailed /*= true*/)
 {
   if (this->m_SocketDescriptor != -1)
     {

--- a/Source/igtlClientSocket.cxx
+++ b/Source/igtlClientSocket.cxx
@@ -41,7 +41,7 @@ ClientSocket::~ClientSocket()
 }
 
 //-----------------------------------------------------------------------------
-int ClientSocket::ConnectToServer(const char* hostName, int port)
+int ClientSocket::ConnectToServer(const char* hostName, int port, bool logErrorIfServerConnectionFailed /*= false*/)
 {
   if (this->m_SocketDescriptor != -1)
     {
@@ -62,7 +62,10 @@ int ClientSocket::ConnectToServer(const char* hostName, int port)
     this->CloseSocket(this->m_SocketDescriptor);
     this->m_SocketDescriptor = -1;
 
-    igtlErrorMacro("Failed to connect to server " << hostName << ":" << port);
+    if( logErrorIfServerConnectionFailed )
+      {
+      igtlErrorMacro("Failed to connect to server " << hostName << ":" << port);
+      }
     return -1;
     }
   return 0;

--- a/Source/igtlClientSocket.h
+++ b/Source/igtlClientSocket.h
@@ -50,7 +50,7 @@ public:
   igtlNewMacro(igtl::ClientSocket);
 
   /// Connects to host. Returns 0 on success, -1 on error.
-  int ConnectToServer(const char* hostname, int port, bool logErrorIfServerConnectionFailed = false); 
+  int ConnectToServer(const char* hostname, int port, bool logErrorIfServerConnectionFailed = true); 
   
 protected:
   ClientSocket();

--- a/Source/igtlClientSocket.h
+++ b/Source/igtlClientSocket.h
@@ -50,7 +50,7 @@ public:
   igtlNewMacro(igtl::ClientSocket);
 
   /// Connects to host. Returns 0 on success, -1 on error.
-  int ConnectToServer(const char* hostname, int port); 
+  int ConnectToServer(const char* hostname, int port, bool logErrorIfServerConnectionFailed = false); 
   
 protected:
   ClientSocket();


### PR DESCRIPTION
When auto-connect is chosen from Slicer, there is continuous spam from the constant reconnect attempts. This change enables the possibility of controlling the output behavior.

Further commits in the Slicer code will disable the log spam.