### PR TITLE
replaced angle brackets by quotation marks (this is the way including is done for all other messages)

### DIFF
--- a/Source/igtlCapabilityMessage.h
+++ b/Source/igtlCapabilityMessage.h
@@ -14,10 +14,10 @@
 #ifndef __igtlCapabilityMessage_h
 #define __igtlCapabilityMessage_h
 
-#include <igtlObject.h>
-#include <igtlMath.h>
-#include <igtlMessageBase.h>
-#include <igtlTypes.h>
+#include "igtlObject.h"
+#include "igtlMath.h"
+#include "igtlMessageBase.h"
+#include "igtlTypes.h"
 
 #include <vector>
 #include <string>


### PR DESCRIPTION
Using angle brackets for the include fails in our environment. All other messages use local, i.e. quotation marks, for including and can be
compiled.