### PR TITLE
Message id and coding scheme improved

### DIFF
--- a/Examples/Imager/ImagerClient3.cxx
+++ b/Examples/Imager/ImagerClient3.cxx
@@ -159,7 +159,8 @@ int ReceiveImageData(igtl::ClientSocket::Pointer& socket, igtl::MessageHeader::P
     {
       for (int i = 0; i <imageData->keys.size(); i++)
       {
-        std::cerr<< imageData->keys[i]<< " " << imageData->values[i] << std::endl;
+        std::cerr<<"The message ID is:"<< " " << imageData->msgId << std::endl;
+        std::cerr<< imageData->keys[i]<< " coding scheme: " <<imageData->valueEncoding[i]<<" "<<imageData->values[i] << std::endl;
       }
     }
     SaveTestImage(imageData, loop);

--- a/Examples/Imager/ImagerServer3.cxx
+++ b/Examples/Imager/ImagerServer3.cxx
@@ -108,7 +108,12 @@ int main(int argc, char* argv[])
               imgMsg->SetDeviceName("ImagerClient");
               imgMsg->SetSubVolume(svsize, svoffset);
               imgMsg->SetVersion(headerMsg->GetVersion());
-              imgMsg->AddMetaDataElement("A stupid idiot", "yes it is");
+              if (headerMsg->GetVersion() == IGTL_HEADER_VERSION_3)
+              {
+                unsigned short codingScheme = 3; // 3 corresponding to US-ASCII
+                imgMsg->AddMetaDataElement("Patient age", codingScheme, "25");
+                imgMsg->SetMsgID(i);
+              }
               imgMsg->AllocateScalars();
               
               //------------------------------------------------------------

--- a/Examples/Point/PointClient3.cxx
+++ b/Examples/Point/PointClient3.cxx
@@ -125,7 +125,8 @@ int main(int argc, char* argv[])
         {
           for (int i = 0; i <pointData->keys.size(); i++)
           {
-            std::cerr<< pointData->keys[i]<< " " << pointData->values[i] << std::endl;
+            std::cerr<<"The message ID is:"<< " " << pointData->msgId << std::endl;
+            std::cerr<< pointData->keys[i]<< " coding scheme: "<<pointData->valueEncoding[i]<<" "<< pointData->values[i] << std::endl;
           }
         }
       }

--- a/Examples/Point/PointServer3.cxx
+++ b/Examples/Point/PointServer3.cxx
@@ -121,8 +121,13 @@ int main(int argc, char* argv[])
               pointMsg->AddPointElement(point1);
               pointMsg->AddPointElement(point2);
               pointMsg->SetVersion(headerMsg->GetVersion());
-              pointMsg->AddMetaDataElement("A stupid idiot", "yes it is");
-              pointMsg->AddMetaDataElement("Two stupid idiot", "yes they are");
+              if (headerMsg->GetVersion() == IGTL_HEADER_VERSION_3)
+              {
+                unsigned short codingScheme = 3; // 3 corresponding to US-ASCII
+                pointMsg->AddMetaDataElement("First patient age", codingScheme, "22");
+                pointMsg->AddMetaDataElement("Second patient age",codingScheme, "25");
+                pointMsg->SetMsgID(i);
+              }
               pointMsg->Pack();
               
               //---------------------------

--- a/Source/igtlMessageBase.cxx
+++ b/Source/igtlMessageBase.cxx
@@ -41,6 +41,7 @@ MessageBase::MessageBase():
   m_Version = IGTL_HEADER_VERSION_3;
   metaDataTotalSize = 2;
   indexCount= 0;
+  msgId = 0;
   m_ExtendedHeader = NULL;
   m_MetaData = NULL;
   keySize.clear();
@@ -123,11 +124,11 @@ std::string MessageBase::GetMessageType() const
 }
 
   
-int MessageBase::AddMetaDataElement(std::string key, std::string value)
+  int MessageBase::AddMetaDataElement(std::string key, igtlUint16 encodingScheme, std::string value)
 {
   igtlUint16 keyLength = key.length();
   this->keySize.push_back(keyLength);
-  this->valueEncoding.push_back(0);
+  this->valueEncoding.push_back(encodingScheme);
   igtlUint16 valueLength = value.length();
   this->valueSize.push_back(valueLength);
   this->keys.push_back(key);
@@ -147,7 +148,7 @@ void MessageBase::PackMetaData()
     igtl_extended_header* extended_header = (igtl_extended_header*) m_ExtendedHeader;
     extended_header->extended_header_size = IGTL_EXTENDED_HEADER_SIZE;
     extended_header->meta_data_size       = this->GetMetaDataSize();
-    extended_header->msg_id               = 0;
+    extended_header->msg_id               = this->GetMsgID();
     extended_header->reserved             = 0;
     igtl_extended_header_convert_byte_order(extended_header);
     igtl_uint16 index_count = this->indexCount; // first two byte are the total number of meta data

--- a/Source/igtlMessageBase.h
+++ b/Source/igtlMessageBase.h
@@ -119,9 +119,21 @@ public:
     metaDataTotalSize = size;
   };
   
+  /// Gets the message ID (length) of packed message
+  igtlUint32 GetMsgID()
+  {
+    return msgId;
+  };
+  
+  void SetMsgID(igtlUint32 idValue)
+  {
+    msgId = idValue;
+  };
+  
+  
   
   /// Add Meta data element
-  int AddMetaDataElement(std::string key, std::string value);
+  int AddMetaDataElement(std::string key, igtlUint16 encodingScheme, std::string value);
   
   /// Pack the meta data
   void PackMetaData();


### PR DESCRIPTION
1. The message id could be set now, previous it was set to 0 and cannot be modified
2. The coding scheme is set to default value "3", which corresponding to US-ASCII2 
3. Example server and client updated accordingly