### PR TITLE
ENH: Enable support for texture coords being accessible by type

### DIFF
--- a/Source/igtlPolyDataMessage.cxx
+++ b/Source/igtlPolyDataMessage.cxx
@@ -500,7 +500,7 @@ void IGTLCommon_EXPORT SetPolyDataInfoAttribute(igtl_polydata_info * info, PolyD
   igtl_polydata_attribute * attr = info->attributes;
   for (unsigned int i = 0; i < info->header.nattributes; i ++)
     {
-    PolyDataAttribute * src =  pdm->GetAttribute(i);
+    PolyDataAttribute * src =  pdm->GetAttribute(static_cast<PolyDataMessage::AttributeList::size_type>(i));
     if (src)
       {
       attr->type = src->GetType();

--- a/Source/igtlPolyDataMessage.cxx
+++ b/Source/igtlPolyDataMessage.cxx
@@ -274,11 +274,10 @@ int PolyDataAttribute::SetType(int t, int n)
         this->m_NComponents = n;
         }
       break;
+    case POINT_TCOORDS:
+    case CELL_TCOORDS:
     case POINT_VECTOR:
     case CELL_VECTOR:
-      valid = 1;
-      this->m_NComponents = 3;
-      break;
     case POINT_NORMAL:
     case CELL_NORMAL:
       valid = 1;
@@ -303,7 +302,7 @@ int PolyDataAttribute::SetType(int t, int n)
     unsigned int n = this->m_Size * this->m_NComponents;
     if (n != this->m_Data.size())
       {
-      // TODO: this may cause unnecesasry memory allocation,
+      // TODO: this may cause unnecessary memory allocation,
       // unless m_Size == 0.
       // Memory should be reallocate just before use.
       this->m_Data.resize(n);
@@ -329,7 +328,7 @@ igtlUint32 PolyDataAttribute::SetSize(igtlUint32 size)
   unsigned int n = this->m_Size * this->m_NComponents;
   if (n != this->m_Data.size())
     {
-    // TODO: this may cause unnecesasry memory allocation.
+    // TODO: this may cause unnecessary memory allocation.
     // Memory should be reallocate just before use.
     this->m_Data.resize(n);
     }
@@ -869,7 +868,7 @@ int PolyDataMessage::GetNumberOfAttributes()
   return this->m_Attributes.size();
 }
 
-PolyDataAttribute * PolyDataMessage::GetAttribute(unsigned int id)
+PolyDataAttribute * PolyDataMessage::GetAttribute(AttributeList::size_type id)
 {
   if (id >= this->m_Attributes.size())
     {
@@ -877,6 +876,32 @@ PolyDataAttribute * PolyDataMessage::GetAttribute(unsigned int id)
     }
 
   return this->m_Attributes[id];
+}
+
+PolyDataAttribute * PolyDataMessage::GetAttribute(const std::string& name)
+{
+  for(AttributeList::size_type i = 0; i < this->m_Attributes.size(); ++i)
+    {
+    if (this->m_Attributes[i]->GetName() == name)
+      {
+        return this->m_Attributes[i];
+      }
+    }
+
+  return NULL;
+}
+
+PolyDataAttribute * PolyDataMessage::GetAttribute(int type)
+{
+  for (AttributeList::size_type i = 0; i < this->m_Attributes.size(); ++i)
+  {
+    if (this->m_Attributes[i]->GetType() == type)
+    {
+      return this->m_Attributes[i];
+    }
+  }
+
+  return NULL;
 }
 
 GetPolyDataMessage::GetPolyDataMessage()

--- a/Source/igtlPolyDataMessage.h
+++ b/Source/igtlPolyDataMessage.h
@@ -246,16 +246,18 @@ class IGTLCommon_EXPORT PolyDataAttribute : public Object {
 
   /// Point and cell types.
   enum {
-    POINT_SCALAR = 0x00,
-    POINT_VECTOR = 0x01,
-    POINT_NORMAL = 0x02,
-    POINT_TENSOR = 0x03,
-    POINT_RGBA   = 0x04,
-    CELL_SCALAR  = 0x10,
-    CELL_VECTOR  = 0x11,
-    CELL_NORMAL  = 0x12,
-    CELL_TENSOR  = 0x13,
-    CELL_RGBA    = 0x14,
+    POINT_SCALAR  = 0x00,
+    POINT_VECTOR  = 0x01,
+    POINT_NORMAL  = 0x02,
+    POINT_TENSOR  = 0x03,
+    POINT_RGBA    = 0x04,
+    POINT_TCOORDS = 0x05,
+    CELL_SCALAR   = 0x10,
+    CELL_VECTOR   = 0x11,
+    CELL_NORMAL   = 0x12,
+    CELL_TENSOR   = 0x13,
+    CELL_RGBA     = 0x14,
+    CELL_TCOORDS  = 0x15
   };
 
  public:
@@ -340,6 +342,8 @@ class IGTLCommon_EXPORT PolyDataAttribute : public Object {
 class IGTLCommon_EXPORT PolyDataMessage: public MessageBase
 {
 public:
+  typedef std::vector<PolyDataAttribute::Pointer> AttributeList;
+
   typedef PolyDataMessage                Self;
   typedef MessageBase                    Superclass;
   typedef SmartPointer<Self>             Pointer;
@@ -393,14 +397,19 @@ public:
   int  GetNumberOfAttributes();
 
   /// Gets an attribute specified by 'id'.
-  PolyDataAttribute * GetAttribute(unsigned int id);
+  PolyDataAttribute * GetAttribute(AttributeList::size_type id);
+
+  /// Gets an attribute specified by 'name'.
+  PolyDataAttribute * GetAttribute(const std::string& name);
+
+  /// Gets an attribute specified by 'type'.
+  PolyDataAttribute * GetAttribute(int type);
  
 protected:
   PolyDataMessage();
   ~PolyDataMessage();
 
 protected:
-
   virtual int  CalculateContentBufferSize();
   virtual int  PackContent();
   virtual int  UnpackContent();
@@ -421,7 +430,7 @@ protected:
   PolyDataCellArray::Pointer  m_TriangleStrips;
 
   /// A list of pointers to the attributes.
-  std::vector<PolyDataAttribute::Pointer> m_Attributes;
+  AttributeList m_Attributes;
 
 };
 


### PR DESCRIPTION
Added a couple of accessors for polydata message

New enum values are added such that they maintain backwards compatibility