### PR TITLE
Fix support for Windows XP applications

### DIFF
--- a/Source/igtlGeneralSocket.cxx
+++ b/Source/igtlGeneralSocket.cxx
@@ -569,7 +569,7 @@ namespace igtl
     dest.sin_family = AF_INET;
     
     // store this IP address in dest:
-    inet_pton(AF_INET, this->IPAddress, &(dest.sin_addr));
+    dest.sin_addr.s_addr = inet_addr(this->IPAddress);
     dest.sin_port = htons(this->PortNum);
     
     int n = sendto(this->m_SocketDescriptor, (char*)data, length, 0, (struct sockaddr*)&dest, sizeof dest);

--- a/Source/igtlUDPServerSocket.cxx
+++ b/Source/igtlUDPServerSocket.cxx
@@ -58,8 +58,7 @@ UDPServerSocket::~UDPServerSocket()
 bool UDPServerSocket::IsMulticastAddreesValid(const char* add)
 {
   //224.0.0.0 through 224.0.0.255, are not routable
-  igtl_uint32 address;
-  inet_pton(AF_INET, add, &(address));// to do: make sure the endian is correct
+  igtl_uint32 address = inet_addr(add); // to do: make sure the endian is correct
   if(igtl_is_little_endian())
   {
     address = BYTE_SWAP_INT32(address);


### PR DESCRIPTION
inet_pton() is not supported on Windows XP
Replaced calls to inet_pton() with inet_addr().

Related to: https://github.com/PlusToolkit/PlusLib/issues/200