### PR TITLE
added stdint.h to compile igtlH264 on linux

### DIFF
--- a/Source/VideoStreaming/igtlH264Encoder.cxx
+++ b/Source/VideoStreaming/igtlH264Encoder.cxx
@@ -44,6 +44,7 @@
  */
 #define _CRT_SECURE_NO_WARNINGS
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 #include <signal.h>


### PR DESCRIPTION
I couldn't compile the latest verison on linux, I had to add this header.