### PR TITLE
COMP: Do not constraint project depending on OpenIGTLink with template-depth of 50

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
   CHECK_CXX_COMPILER_FLAG("-fno-tree-vectorize" OpenIGTLink_GNUCXX_TREE_VECTORIZE_SUPPORT)
   IF(OpenIGTLink_GNUCXX_TREE_VECTORIZE_SUPPORT)
     SET(OpenIGTLink_REQUIRED_C_FLAGS "${OpenIGTLink_REQUIRED_C_FLAGS} -w -fno-tree-vectorize")
-    SET(OpenIGTLink_REQUIRED_CXX_FLAGS "${OpenIGTLink_REQUIRED_CXX_FLAGS} -ftemplate-depth-50 -fno-tree-vectorize")
+    SET(OpenIGTLink_REQUIRED_CXX_FLAGS "${OpenIGTLink_REQUIRED_CXX_FLAGS} -ftemplate-depth-900 -fno-tree-vectorize")
   ENDIF()
 
   # If the library is built as a static library, pass -fPIC option to the compiler


### PR DESCRIPTION
This commit increases the template-depth to 900 to avoid compilation issue
when building application with C++11 against Qt5.

The value of 900 was selected because it is the default with gcc.
See https://gcc.gnu.org/onlinedocs/gcc-4.8.2/gcc/C_002b_002b-Dialect-Options.html#C_002b_002b-Dialect-Options
and https://stackoverflow.com/questions/23374953/why-does-this-exceed-the-maximum-recursive-template-depth#comment35810463_23376156