### PR TITLE
Fix indexing of type array after conversion

### DIFF
--- a/Source/igtlNDArrayMessage.h
+++ b/Source/igtlNDArrayMessage.h
@@ -91,8 +91,8 @@ public:
   int                     SetValue(IndexType index, T value)
   {
     if (Get1DIndex(index) <= GetNumberOfElements()) {
-      T* ByteArray = (T*)GetRawArray();
-      ByteArray[Get1DIndex(index) * sizeof(T)] = value;
+      T* TypeArray = reinterpret_cast<T*>(GetRawArray());
+      TypeArray[Get1DIndex(index)] = value;
       return 1;
     } else {
       return 0;
@@ -103,8 +103,8 @@ public:
   int                     GetValue(IndexType index,  T & value)
   {
     if (Get1DIndex(index) <= GetNumberOfElements()) {
-      T* ByteArray = (T*)GetRawArray();
-      value = ByteArray[Get1DIndex(index) * sizeof(T)];
+      T* TypeArray = reinterpret_cast<T*>(GetRawArray());
+      value = TypeArray[Get1DIndex(index)];
       return 1;
     } else {
       return 0;


### PR DESCRIPTION
I noticed that the size of the type in the `Array<T>` type is taken twice into account.
Previously this code used bytewise indexing, which made necessary multiplying the input index with the size of the type:
https://github.com/openigtlink/OpenIGTLink/blob/5acf3b41a91160b3bb875fd3bb66ae87596e4ea2/Source/igtlNDArrayMessage.h#L94
However, after casting the raw array to `T*` in the `ByteArray` variable, indexing already takes into account the size of the type.
The current code would produce out-of-bounds access for types with size > 1 byte and input indices > 1.
https://github.com/openigtlink/OpenIGTLink/blob/1d6cd5ce750e3b4edba340646247d1b297ea43fa/Source/igtlNDArrayMessage.h#L95

Additionally, I changed the variable name to `TypeArray` to make it clearer and used `reinterpret_cast` instead of C-style cast.