### PR TITLE
Bug fixed. message need to be allocated as much  as  the body size.

### DIFF
--- a/Source/igtlMessageHandlerMacro.h
+++ b/Source/igtlMessageHandlerMacro.h
@@ -51,7 +51,7 @@
       if (pos == 0) /* New body */                                      \
         {                                                               \
         this->m_Message->SetMessageHeader(header);                      \
-        this->m_Message->InitBuffer();                                  \
+        this->m_Message->AllocateBuffer();                                  \
         }                                                               \
       int s = socket->Receive((void*)((char*)this->m_Message->GetBufferBodyPointer()+pos), \
                               this->m_Message->GetBufferBodySize()-pos);  \


### PR DESCRIPTION
InitBuffer() function allocate the memory as much as the header(58)

version 3.0 or later session manager doesn't work with message handler.
I fixed it. please compare current code with the code of release 2.x