### PR TITLE
FEATURE: I444 data format added for compression using VP9

### DIFF
--- a/Source/VideoStreaming/igtlCodecCommonClasses.h
+++ b/Source/VideoStreaming/igtlCodecCommonClasses.h
@@ -28,10 +28,11 @@
 namespace igtl {
 
 /**
- * @brief Enumerate the type of video format
+ * @brief Enumerate the type of video format,  Only YV12, I420, I422, I444 images are supported in the codec. RGB format are not supported yet.
  */
 typedef enum {
-  FormatI420       = 1     //// only YUV420 is supported now
+  FormatI420       = 1,     ////  YUV420
+  FormatI444        = 2     //// I444,
 } VideoFormatType;
 
 typedef enum {

--- a/Source/VideoStreaming/igtlVP9Decoder.h
+++ b/Source/VideoStreaming/igtlVP9Decoder.h
@@ -66,7 +66,7 @@ public:
   virtual int DecodeVideoMSGIntoSingleFrame(igtl::VideoMessage* videoMessage, SourcePicture* pDecodedPic);
   
 private:
-  virtual void ComposeByteSteam(igtl_uint8** inputData, int dimension[2], int iStride[2], igtl_uint8 *outputFrame);
+  virtual void ComposeByteSteam(igtl_uint8** inputData, int dimension[2], int iStride[2], igtl_uint8 *outputFrame, VideoFormatType format);
   
   const VpxInterfaceDecoder* decoder;
   

--- a/Source/VideoStreaming/igtlVP9Encoder.h
+++ b/Source/VideoStreaming/igtlVP9Encoder.h
@@ -74,6 +74,8 @@ public:
   virtual unsigned int GetPicHeight(){return this->picHeight;};
   
   virtual int SetRCMode(int value);
+
+  virtual int SetImageFormat(VideoFormatType value);
   
   virtual int SetKeyFrameDistance(int frameNum);
   


### PR DESCRIPTION
The user will have the possibility to send RGB or YUV444 data directly. This will have great benefit as the current I420 format requires user to convert RGB data to YUV420, which will cause color lost.