### PR TITLE
Revert "ENH: Adding parameter to Pack() to make crc calculation optional"

### DIFF
--- a/Source/igtlMessageBase.cxx
+++ b/Source/igtlMessageBase.cxx
@@ -523,7 +523,7 @@ void MessageBase::GetTimeStamp(igtl::TimeStamp::Pointer& ts)
 }
 
 
-int MessageBase::Pack(bool crccheck)
+int MessageBase::Pack()
 {
   if (m_IsBodyPacked)
     {
@@ -562,14 +562,7 @@ int MessageBase::Pack(bool crccheck)
 
   h->timestamp = ts;
   h->body_size = GetBufferBodySize();
-  if (crccheck)
-    {
-    h->crc = crc64((unsigned char*)m_Body, h->body_size, crc);
-    }
-  else
-    {
-    h->crc = 0;
-    }
+  h->crc       = crc64((unsigned char*)m_Body, h->body_size, crc);
 
   strncpy(h->name, m_SendMessageType.c_str(), 12);
 

--- a/Source/igtlMessageBase.h
+++ b/Source/igtlMessageBase.h
@@ -187,7 +187,7 @@ namespace igtl
 
     /// Pack() serializes the header and body based on the member variables.
     /// PackContent() must be implemented in the child class.
-    virtual int Pack(bool crccheck = true);
+    virtual int Pack();
 
     /// Unpack() deserializes the header and/or body, extracting data from
     /// the byte stream. If the header has already been deserilized, Unpack()


### PR DESCRIPTION
Reverts openigtlink/OpenIGTLink#230,
crc option flag needs to be sent via meta data and is only available for header_version 2. 