### PR TITLE
BUG: set CMAKE_FLAGS based on OpenIGTLink_REQUIRED_FLAGS *before* cal…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,14 @@ ELSE()
 ENDIF()
 
 #-----------------------------------------------------------------------------
+# Add compiler flags OpenIGTLink needs to work on this platform
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenIGTLink_REQUIRED_C_FLAGS}")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenIGTLink_REQUIRED_CXX_FLAGS}")
+SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenIGTLink_REQUIRED_LINK_FLAGS}")
+SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${OpenIGTLink_REQUIRED_LINK_FLAGS}")
+SET(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${OpenIGTLink_REQUIRED_LINK_FLAGS}")
+
+#-----------------------------------------------------------------------------
 # Configure Subdirectories
 ADD_SUBDIRECTORY(Source/igtlutil)
 ADD_SUBDIRECTORY(Source)
@@ -266,14 +274,6 @@ INSTALL(FILES
   DESTINATION ${OpenIGTLink_INSTALL_INCLUDE_DIR}
   COMPONENT Development
   )
-
-#-----------------------------------------------------------------------------
-# Add compiler flags OpenIGTLink needs to work on this platform
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenIGTLink_REQUIRED_C_FLAGS}")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenIGTLink_REQUIRED_CXX_FLAGS}")
-SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenIGTLink_REQUIRED_LINK_FLAGS}")
-SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${OpenIGTLink_REQUIRED_LINK_FLAGS}")
-SET(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${OpenIGTLink_REQUIRED_LINK_FLAGS}")
 
 #-----------------------------------------------------------------------------
 # Export targets


### PR DESCRIPTION
…ls to ADD_SUBDIRECTORY so flags are applied to the library itself (e.g. -fPIC was not applied when compiling a static library)