### PR TITLE
Override/Virtual issues

### DIFF
--- a/Source/igtlImageMessage.h
+++ b/Source/igtlImageMessage.h
@@ -266,13 +266,13 @@ public:
 
 protected:
   ImageMessage();
-  ~ImageMessage();
+  ~ImageMessage() override;
   
 protected:
 
-  virtual int  CalculateContentBufferSize();
-  virtual int  PackContent();
-  virtual int  UnpackContent();
+  int  CalculateContentBufferSize() override;
+  int  PackContent() override;
+  int  UnpackContent() override;
 
   /// A vector containing the numbers of voxels in i, j and k directions.
   int    dimensions[3];

--- a/Source/igtlMacro.h
+++ b/Source/igtlMacro.h
@@ -420,7 +420,7 @@ static Pointer New(void) \
   smartPtr->UnRegister(); \
   return smartPtr; \
 } \
-virtual ::igtl::LightObject::Pointer CreateAnother(void) const \
+::igtl::LightObject::Pointer CreateAnother(void) const override\
 { \
   return x::New().GetPointer(); \
 } \
@@ -461,7 +461,7 @@ static Pointer New(void) \
 /** Macro used to add standard methods and typedef to all classes, mainly type
  * information. */
 #define igtlTypeMacro(thisClass,superclass) \
-    virtual const char *GetNameOfClass() const {return #thisClass;} \
+    const char *GetNameOfClass() const override {return #thisClass;} \
     typedef thisClass Self; \
     typedef superclass Superclass; \
     typedef igtl::SmartPointer<Self> Pointer; \

--- a/Source/igtlMessageBase.h
+++ b/Source/igtlMessageBase.h
@@ -379,16 +379,16 @@ namespace igtl
     ~HeaderOnlyMessageBase() {};
 
   protected:
-    virtual int  CalculateContentBufferSize()
+    int  CalculateContentBufferSize() override
     {
       return 0;
     };
-    virtual int  PackContent()
+    int  PackContent() override
     {
       AllocateBuffer();
       return 1;
     };
-    virtual int  UnpackContent()
+    int  UnpackContent() override
     {
       return 1;
     };

--- a/Source/igtlObject.h
+++ b/Source/igtlObject.h
@@ -72,7 +72,7 @@ public:
    * object that is exactly the same type as the referring object.
    * This is useful in cases where an object has been cast back to a
    * base class. */
-  virtual LightObject::Pointer CreateAnother() const;
+  LightObject::Pointer CreateAnother() const override;
 
   /** Turn debugging output on.  */
   virtual void DebugOn() const;
@@ -94,13 +94,13 @@ public:
   //  virtual void Modified() const;
   
   /** Increase the reference count (mark as used by another object).  */
-  virtual void Register() const;
+  void Register() const override;
 
   /** Decrease the reference count (release by another object).  */
-  virtual void UnRegister() const;
+  void UnRegister() const override;
 
   /** Sets the reference count (use with care)  */
-  virtual void SetReferenceCount(int);
+  void SetReferenceCount(int) override;
 
   /** This is a global flag that controls whether any debug, warning
    *  or error messages are displayed.  */

--- a/Source/igtlObjectFactoryBase.h
+++ b/Source/igtlObjectFactoryBase.h
@@ -146,7 +146,7 @@ public:
     };
 
 protected:
-  virtual void PrintSelf(std::ostream& os) const;
+  void PrintSelf(std::ostream& os) const override;
 
   /** Register object creation information with the factory. */
   void RegisterOverride(const char* classOverride,

--- a/Source/igtlPointMessage.h
+++ b/Source/igtlPointMessage.h
@@ -120,11 +120,11 @@ public:
 
 protected:
   GetPointMessage() : MessageBase() { this->m_SendMessageType  = "GET_POINT"; };
-  ~GetPointMessage() {};
+  ~GetPointMessage() override {};
 protected:
-  virtual int  CalculateContentBufferSize() { return 0; };
-  virtual int  PackContent()        { AllocateBuffer(); return 1; };
-  virtual int  UnpackContent()      { return 1; };
+  int  CalculateContentBufferSize() override { return 0; };
+  int  PackContent() override        { AllocateBuffer(); return 1; };
+  int  UnpackContent() override      { return 1; };
 };
 
 
@@ -154,13 +154,13 @@ public:
 
 protected:
   PointMessage();
-  ~PointMessage();
+  ~PointMessage() override;
   
 protected:
 
-  virtual int  CalculateContentBufferSize();
-  virtual int  PackContent();
-  virtual int  UnpackContent();
+  int  CalculateContentBufferSize() override;
+  int  PackContent() override;
+  int  UnpackContent() override;
 
   /// A list of pointers to the points.
   std::vector<PointElement::Pointer> m_PointList;

--- a/Source/igtlStatusMessage.h
+++ b/Source/igtlStatusMessage.h
@@ -110,9 +110,9 @@ protected:
   
 protected:
 
-  virtual int  CalculateContentBufferSize();
-  virtual int  PackContent();
-  virtual int  UnpackContent();
+  int  CalculateContentBufferSize() override;
+  int  PackContent() override;
+  int  UnpackContent() override;
 
   /// The error code.
   igtlUint16   m_Code;

--- a/Source/igtlStringMessage.h
+++ b/Source/igtlStringMessage.h
@@ -56,13 +56,13 @@ public:
 
 protected:
   StringMessage();
-  ~StringMessage();
+  ~StringMessage() override;
   
 protected:
 
-  virtual int  CalculateContentBufferSize();
-  virtual int  PackContent();
-  virtual int  UnpackContent();
+  int  CalculateContentBufferSize() override;
+  int  PackContent() override;
+  int  UnpackContent() override;
   
   /// The encoding of the string.
   /// The value is defined in IANA Character Sets (http://www.iana.org/assignments/character-sets).

--- a/Source/igtlTimeStamp.h
+++ b/Source/igtlTimeStamp.h
@@ -80,7 +80,7 @@ protected:
   virtual ~TimeStamp();
 
   /** Print the object information in a stream. */
-  virtual void PrintSelf( std::ostream& os) const;
+  void PrintSelf( std::ostream& os) const override;
 
 private:
 

--- a/Source/igtlTransformMessage.h
+++ b/Source/igtlTransformMessage.h
@@ -88,9 +88,9 @@ protected:
   
 protected:
 
-  virtual int  CalculateContentBufferSize();
-  virtual int  PackContent();
-  virtual int  UnpackContent();
+  int  CalculateContentBufferSize() override;
+  int  PackContent() override;
+  int  UnpackContent() override;
   
   /// The transformation matrix.
   Matrix4x4 matrix;


### PR DESCRIPTION
GetNameOfClass and CreateAnother have to override the virtual methods of the base class. This is required to build OpenIGTLink in our environment with strict compiler warning/error handling.