### PR TITLE
MetaDataValidation

### DIFF
--- a/Source/igtlMessageBase.cxx
+++ b/Source/igtlMessageBase.cxx
@@ -458,7 +458,7 @@ bool MessageBase::UnpackMetaData()
     igtl_metadata_header_entry entry;
     unsigned char* entryPointer = &m_MetaDataHeader[META_DATA_INDEX_COUNT_SIZE];
     const igtl_uint16 metaDataHeaderSize = ((igtl_extended_header*)m_ExtendedHeader)->meta_data_header_size;
-    igtl_uint16 currentMetaDataHeaderRead = 0;
+    igtl_uint32 currentMetaDataHeaderRead = 0;
     for (int i = 0; i < index_count; i++)
       {
       currentMetaDataHeaderRead += sizeof(igtl_metadata_header_entry);
@@ -486,7 +486,7 @@ bool MessageBase::UnpackMetaData()
 
     unsigned char* metaDataPointer = m_MetaData;
     const igtl_uint16 metaDataSize = ((igtl_extended_header*)m_ExtendedHeader)->meta_data_size;
-    igtl_uint16 currentMetaDataRead = 0;
+    igtl_uint32 currentMetaDataRead = 0;
     for (int i = 0; i < index_count; i++)
       {
       currentMetaDataRead += metaDataEntries[i].key_size + metaDataEntries[i].value_size;

--- a/Testing/igtlStatusMessageTest.cxx
+++ b/Testing/igtlStatusMessageTest.cxx
@@ -65,6 +65,28 @@ TEST(StatusMessageTest, Unpack)
 }
 
 
+{
+  statusSendMsg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
+  statusSendMsg->SetMetaDataElement("metaData1", 1);
+  statusSendMsg->AllocatePack();
+  statusSendMsg->Pack();
+
+  // set an invalid meta data element number to force wrong memory access 
+  ((char*)statusSendMsg->GetBufferPointer())[statusSendMsg->GetBufferSize() - 13] = 20;
+
+  igtl::MessageHeader::Pointer headerMsg = igtl::MessageHeader::New();
+  headerMsg->AllocatePack();
+  memcpy(headerMsg->GetPackPointer(), statusSendMsg->GetPackPointer(), IGTL_HEADER_SIZE); 
+  headerMsg->Unpack();
+
+  statusReceiveMsg->SetMessageHeader(headerMsg);
+  statusReceiveMsg->AllocatePack();
+  memcpy(statusReceiveMsg->GetPackBodyPointer(), statusSendMsg->GetPackBodyPointer(), statusSendMsg->GetPackBodySize());
+  
+  EXPECT_NE(statusReceiveMsg->Unpack(), igtl::MessageBase::UNPACK_BODY);
+}
+
+
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/Testing/igtlStatusMessageTest.cxx
+++ b/Testing/igtlStatusMessageTest.cxx
@@ -65,6 +65,7 @@ TEST(StatusMessageTest, Unpack)
 }
 
 
+#if OpenIGTLink_HEADER_VERSION >= 2
 TEST(StatusMessageTest, UnpackInvalidMetaData)
 {
   statusSendMsg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
@@ -86,6 +87,7 @@ TEST(StatusMessageTest, UnpackInvalidMetaData)
   
   EXPECT_NE(statusReceiveMsg->Unpack(), igtl::MessageBase::UNPACK_BODY);
 }
+#endif
 
 
 int main(int argc, char **argv)

--- a/Testing/igtlStatusMessageTest.cxx
+++ b/Testing/igtlStatusMessageTest.cxx
@@ -65,6 +65,7 @@ TEST(StatusMessageTest, Unpack)
 }
 
 
+TEST(StatusMessageTest, UnpackInvalidMetaData)
 {
   statusSendMsg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
   statusSendMsg->SetMetaDataElement("metaData1", 1);


### PR DESCRIPTION
It is possible to crash receivers by sending messages with corrupted meta data information, because there is no validation of the meta data length that is send. Thus, other OpenIGTLink end points can easily be crashed by sending such messages.

Furthermore, such a failed message unpacking is not propagated along the call hierarchy resulting in further processing of corrupted/invalid messages.

- ensure that amount of bytes read from metaData does not exceed expected meta data length
- do not set m_IsBodyUnpacked and UNPACK_BODY if unpacking failed