### PR TITLE
BUG: Fix error when unpacking messages with v1 header

### DIFF
--- a/Source/igtlMessageBase.cxx
+++ b/Source/igtlMessageBase.cxx
@@ -908,11 +908,17 @@ void MessageBase::UnpackBody(int crccheck, int& r)
     bool unpackSuccessful = true;
     // Unpack (deserialize) the Body
 #if OpenIGTLink_HEADER_VERSION >= 2
-    unpackSuccessful &= UnpackExtendedHeader();
+    if (h->header_version >= 2)
+    {
+      unpackSuccessful &= UnpackExtendedHeader();
+    }
 #endif
     unpackSuccessful &= UnpackContent();
 #if OpenIGTLink_HEADER_VERSION >= 2
-    unpackSuccessful &= UnpackMetaData();
+    if (h->header_version >= 2)
+    {
+      unpackSuccessful &= UnpackMetaData();
+    }
 #endif
     m_IsBodyUnpacked = unpackSuccessful;
     if (unpackSuccessful)


### PR DESCRIPTION
When unpacking a message with a v1 header, igtlMessageBase::UnpackHeader attempted to unpack the extended header and metadata. This resulted in failure since neither are valid for v1 headers.

Fixed by only attempting to unpack the extended header and metadata for header version >= 2.