### PR TITLE
FIX: Video streaming build fixes

### DIFF
--- a/Examples/VideoStreaming/VideoClient.cxx
+++ b/Examples/VideoStreaming/VideoClient.cxx
@@ -103,7 +103,8 @@ int main(int argc, char* argv[])
     igtl::MessageHeader::Pointer headerMsg;
     headerMsg = igtl::MessageHeader::New();
     headerMsg->InitPack();
-    int rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize());
+    bool timeout(false);
+    igtlUint64 rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize(), timeout);
     if (rs == 0)
       {
       std::cerr << "Connection closed." << std::endl;
@@ -156,7 +157,8 @@ int ReceiveVideoData(igtl::ClientSocket::Pointer& socket, igtl::MessageHeader::P
   videoMsg->AllocatePack();
   
   // Receive body from the socket
-  socket->Receive(videoMsg->GetPackBodyPointer(), videoMsg->GetPackBodySize());
+  bool timeout(false);
+  socket->Receive(videoMsg->GetPackBodyPointer(), videoMsg->GetPackBodySize(), timeout);
   
   // Deserialize the transform data
   // If you want to skip CRC check, call Unpack() without argument.

--- a/Examples/VideoStreaming/VideoMetaClient.cxx
+++ b/Examples/VideoStreaming/VideoMetaClient.cxx
@@ -72,7 +72,8 @@ int main(int argc, char* argv[])
     igtl::MessageHeader::Pointer headerMsg;
     headerMsg = igtl::MessageHeader::New();
     headerMsg->InitPack();
-    int rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize());
+    bool timeout(false);
+    igtlUint64 rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize(), timeout);
     if (rs == 0)
       {
       std::cerr << "Connection closed." << std::endl;
@@ -118,7 +119,8 @@ int ReceiveVideoMeta(igtl::ClientSocket::Pointer& socket, igtl::MessageHeader::P
   videoMeta->AllocatePack();
   
   // Receive transform data from the socket
-  socket->Receive(videoMeta->GetPackBodyPointer(), videoMeta->GetPackBodySize());
+  bool timeout(false);
+  socket->Receive(videoMeta->GetPackBodyPointer(), videoMeta->GetPackBodySize(), timeout);
   
   // Deserialize the transform data
   // If you want to skip CRC check, call Unpack() without argument.

--- a/Examples/VideoStreaming/VideoMetaServer.cxx
+++ b/Examples/VideoStreaming/VideoMetaServer.cxx
@@ -77,7 +77,8 @@ int main(int argc, char* argv[])
         headerMsg->InitPack();
 
         // Receive generic header from the socket
-        int rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize());
+        bool timeout(false);
+        igtlUint64 rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize(), timeout);
         if (rs == 0)
           {
           socket->CloseSocket();

--- a/Examples/VideoStreaming/VideoServer.cxx
+++ b/Examples/VideoStreaming/VideoServer.cxx
@@ -119,7 +119,8 @@ int main(int argc, char* argv[])
         headerMsg->InitPack();
 
         // Receive generic header from the socket
-        int rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize());
+        bool timeout(false);
+        igtlUint64 rs = socket->Receive(headerMsg->GetPackPointer(), headerMsg->GetPackSize(), timeout);
         if (rs <= 0)
           {
           if (threadID >= 0)

--- a/SuperBuild/External_openh264.cmake
+++ b/SuperBuild/External_openh264.cmake
@@ -9,7 +9,7 @@ IF(OpenH264_FOUND)
 ELSE()
   # OpenIGTLink has not been built yet, so download and build it as an external project
   MESSAGE(STATUS "Downloading openh264 from https://github.com/cisco/openh264.git.")  
-  SET (OpenH264_INCLUDE_DIR "${CMAKE_BINARY_DIR}/Deps/openh264/codec/api/svc" CACHE PATH "H264 source directory" FORCE)
+  SET (OpenH264_INCLUDE_DIR "${CMAKE_BINARY_DIR}/Deps/openh264/codec/api/wels" CACHE PATH "H264 source directory" FORCE)
   SET (OpenH264_LIBRARY_DIR "${CMAKE_BINARY_DIR}/Deps/openh264" CACHE PATH "H264 source directory" FORCE)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")     
     ExternalProject_Add(OpenH264


### PR DESCRIPTION
Update openh264 include path
Update video streaming example to new Receive() with timeout

openh264 [commit 3164a792a8a22f9d7456c7e2db9280ce5cc7e31b](https://github.com/cisco/openh264/commit/3164a792a8a22f9d7456c7e2db9280ce5cc7e31b) has moved the `codec/api/svc` directory to `codec/api/wels` which breaks video streaming + h264 build.

Additionally, updates the video streaming examples to use new Socket::Receive() function prototype.