### PR TITLE
FIX: make code compile under C++20

### DIFF
--- a/Source/igtlLightObject.cxx
+++ b/Source/igtlLightObject.cxx
@@ -198,21 +198,9 @@ LightObject
   /**
    * warn user if reference counting is on and the object is being referenced
    * by another object.
-   * a call to uncaught_exception is necessary here to avoid throwing an
-   * exception if one has been thrown already. This is likely to
-   * happen when a subclass constructor (say B) is throwing an exception: at
-   * that point, the stack unwinds by calling all superclass destructors back
-   * to this method (~LightObject): since the ref count is still 1, an 
-   * exception would be thrown again, causing the system to abort()!
    */
-  if(m_ReferenceCount > 0 && !std::uncaught_exception())
+  if(m_ReferenceCount > 0)
     {
-    // A general exception safety rule is that destructors should
-    // never throw.  Something is wrong with a program that reaches
-    // this point anyway.  Also this is the least-derived class so the
-    // whole object has been destroyed by this point anyway.  Just
-    // issue a warning.
-    // igtlExceptionMacro(<< "Trying to delete object with non-zero reference count.");
     igtlWarningMacro("Trying to delete object with non-zero reference count.");
     }
 }


### PR DESCRIPTION
In the destructor of the igtlLightObject, a call to
std::uncaught_exception was used. This function was deprecated in C++17
and then removed in C++20, which causes OpenIGTLink to fail compilation
on Visual Studio if C++20 is enabled.
Judging from the comments in the code, the call was unnecessary, so it
was removed.