### PR TITLE
FIX: make sure to assign string literals to `const char*`

### DIFF
--- a/Source/igtlLightObject.cxx
+++ b/Source/igtlLightObject.cxx
@@ -214,12 +214,12 @@ void
 LightObject
 ::PrintSelf(std::ostream& os) const
 {
+  const char* indent = "    ";
+
 #ifdef GCC_USEDEMANGLE
   char const * mangledName = typeid(*this).name();
   int status;
   char* unmangled = abi::__cxa_demangle(mangledName, 0, 0, &status);
-
-  const char* indent = "    ";
 
   os << indent << "RTTI typeinfo:   ";
 
@@ -235,7 +235,6 @@ LightObject
 
   os << std::endl;
 #else
-  char* indent = "    ";  
   os << indent << "RTTI typeinfo:   " << typeid( *this ).name() << std::endl;
 #endif
   os << indent << "Reference Count: " << m_ReferenceCount << std::endl;


### PR DESCRIPTION
Assigning string literals to `char*` has been [illegal since C++11][1], but Visual Studio only started to enforce this in C++20 mode, where the [`/permissive` flag is disabled by default][2]. With this small change, the project now also compiles in Visual Studio's C++20 mode.

[1]: https://en.cppreference.com/w/cpp/language/string_literal
[2]: https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-160