### PR TITLE
Memory leaks corrected and. socket timeout handling improved.

### DIFF
--- a/Source/igtlBindMessage.cxx
+++ b/Source/igtlBindMessage.cxx
@@ -281,6 +281,8 @@ int BindMessage::UnpackContent()
 
     }
 
+  igtl_bind_free_info(&bind_info);
+
   return 1;
 }
 

--- a/Source/igtlMessageHandlerMacro.h
+++ b/Source/igtlMessageHandlerMacro.h
@@ -37,24 +37,24 @@ using igtl::SmartPointer;
     igtlTypeMacro(classname, ::igtl::MessageHandler);             \
     igtlNewMacro(classname);                                      \
   public:                                                         \
-    virtual const char* GetMessageType()                          \
+    virtual const char* GetMessageType() override                 \
     {                                                             \
       return this->m_Message->GetDeviceType();                    \
     }                                                             \
     virtual int Process(messagetype*, datatype*);                 \
-    igtl_uint64 ReceiveMessage(::igtl::Socket* socket, ::igtl::MessageBase* header, int pos) \
+    igtl_uint64 ReceiveMessage(::igtl::Socket* socket, ::igtl::MessageBase* header, int pos) override \
     {                                                                   \
       if (pos == 0) /* New body */                                      \
         {                                                               \
         this->m_Message->SetMessageHeader(header);                      \
         this->m_Message->AllocateBuffer();                              \
         }                                                               \
-      bool timeout(false);                                              \
+      bool error(false);                                              \
       igtl_uint64 s = socket->Receive((void*)((char*)this->m_Message->GetBufferBodyPointer()+pos), \
-                              this->m_Message->GetBufferBodySize()-pos, timeout);                  \
-      if (timeout) /* Time out */                                       \
+                              this->m_Message->GetBufferBodySize()-pos, error);                  \
+      if (error) /* Not time out */                                       \
         {                                                               \
-        return pos;                                                     \
+        return -1;                                                     \
         }                                                               \
       if (s+pos >= this->m_Message->GetBufferBodySize())                \
         {                                                               \
@@ -114,12 +114,12 @@ using igtl::SmartPointer;
     {                                                                   \
       return this->m_Message->GetMessageType();                         \
     }                                                                   \
-    virtual const char* GetMessageType()                                \
+    virtual const char* GetMessageType() override                       \
     {                                                                   \
       return this->m_Message->GetDeviceType();                          \
     }                                                                   \
     virtual int Process(messagetype*, datatype*);                       \
-    igtl_uint64 ReceiveMessage(::igtl::Socket* socket, ::igtl::MessageBase* header, int pos) \
+    igtl_uint64 ReceiveMessage(::igtl::Socket* socket, ::igtl::MessageBase* header, int pos) override \
     {                                                                   \
       if (pos == 0) /* New body */                                      \
         {                                                               \

--- a/Source/igtlNDArrayMessage.cxx
+++ b/Source/igtlNDArrayMessage.cxx
@@ -149,6 +149,11 @@ NDArrayMessage::NDArrayMessage():
 
 NDArrayMessage::~NDArrayMessage()
 {
+    if (m_Array != NULL)
+    {
+        delete m_Array;
+        m_Array = NULL;
+    }
 }
 
 
@@ -165,15 +170,19 @@ int NDArrayMessage::SetArray(int type, ArrayBase * a)
 
   if (a)
     {
-    this->m_Array = a;
-    return 1;
+      if (this->m_Array)
+	  {
+		delete this->m_Array;
+	  }
+
+      this->m_Array = a;
+      return 1;
     }
   else
     {
     return 0;
     }
 }
-
 
 igtlUint64 NDArrayMessage::CalculateContentBufferSize()
 {
@@ -231,6 +240,8 @@ int NDArrayMessage::PackContent()
   memcpy(info.array, this->m_Array->GetRawArray(), this->m_Array->GetRawArraySize());
   igtl_ndarray_pack(&info, this->m_Content, IGTL_TYPE_PREFIX_NONE);
 
+  igtl_ndarray_free_info(&info);
+
   return 1;
 }
 
@@ -285,7 +296,9 @@ int NDArrayMessage::UnpackContent()
 
   this->m_Array->SetSize(size);
   memcpy(this->m_Array->GetRawArray(), info.array, this->m_Array->GetRawArraySize());
-  
+
+  igtl_ndarray_free_info(&info);
+
   return 1;
 }
 

--- a/Source/igtlNDArrayMessage.h
+++ b/Source/igtlNDArrayMessage.h
@@ -36,9 +36,9 @@ public:
 
 protected:
   ArrayBase();
-  ~ArrayBase();
 
 public:
+  virtual ~ArrayBase();
 
   /// Sets the size of the N-D array. Returns non-zero value, if success.
   int                     SetSize(IndexType size);
@@ -47,7 +47,7 @@ public:
   IndexType               GetSize()         { return this->m_Size;      };
 
   /// Gets the dimension of the N-D array.
-  int                     GetDimension()    { return this->m_Size.size(); };
+  int                     GetDimension()    { return static_cast<int>(this->m_Size.size()); };
 
   /// Sets an array from a byte array. Size and dimension must be specified prior to 
   /// calling the SetArray() function.

--- a/Source/igtlSessionManager.h
+++ b/Source/igtlSessionManager.h
@@ -58,6 +58,7 @@ class IGTLCommon_EXPORT SessionManager: public Object
   int            Disconnect();
   int            ProcessMessage();
   int            PushMessage(MessageBase*);
+  void           ResetMessageProcessing();
 
  protected:
   SessionManager();

--- a/Source/igtlSocket.h
+++ b/Source/igtlSocket.h
@@ -89,7 +89,7 @@ public:
   /// read from the socket. The readFully flag will be ignored if the timeout is active.
   /// 0 on error, else number of bytes read is returned.
   /// On timeout, the timeout variable will be set to true and the return value is ignored
-  igtlUint64 Receive(void* data, igtlUint64 length, bool& timeout, int readFully=1);
+  igtlUint64 Receive(void* data, igtlUint64 length, bool& error, int readFully=1);
 
   /// Set sending/receiving timeout for the existing socket in millisecond.
   /// This function should be called after opening the socket.


### PR DESCRIPTION
- Added missing calls to functions that free memory to correct memory leak.
- m_Array variable's memory managed in NDArrayMessage.
- When receiving data from a socket, handle timeouts differently than errors.
- Bug corrected when increasing m_CurrentReadIndex when just part of the body has been received.