### PR TITLE
BUG: Call shutdown when closing socket on Windows

### DIFF
--- a/Source/igtlSocket.cxx
+++ b/Source/igtlSocket.cxx
@@ -47,7 +47,11 @@
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define WSA_VERSION MAKEWORD(1,1)
-#define igtlCloseSocketMacro(sock) (closesocket(sock))
+#define igtlCloseSocketMacro(sock) \
+      {                            \
+        shutdown(sock, SD_BOTH);   \
+        closesocket(sock);         \
+      }
 #else
 #define igtlCloseSocketMacro(sock) \
       {                            \


### PR DESCRIPTION
Before closing a socket, the application should call shutdown to ensure that all data is sent and received on the closed socket. If closesocket is called without calling shutdown, any data that has not been sent may be lost.

https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-closesocket