### PR TITLE
Fix spelling error in SetRCTargetBitRate

### DIFF
--- a/Source/VideoStreaming/igtlCodecCommonClasses.h
+++ b/Source/VideoStreaming/igtlCodecCommonClasses.h
@@ -158,7 +158,7 @@ public:
   
   virtual int SetQP(int maxQP, int minQP){return -1;};
   
-  virtual int SetRCTaregetBitRate(unsigned int bitRate){return -1;};
+  virtual int SetRCTargetBitRate(unsigned int bitRate){return -1;};
   
   virtual int SetPicWidthAndHeight(unsigned int Width, unsigned int Height){return -1;};
   

--- a/Source/VideoStreaming/igtlH264Encoder.cxx
+++ b/Source/VideoStreaming/igtlH264Encoder.cxx
@@ -184,7 +184,7 @@ int H264Encoder::FillSpecificParameters() {
   return 0;
 }
 
-int H264Encoder::SetRCTaregetBitRate(unsigned int bitRate)
+int H264Encoder::SetRCTargetBitRate(unsigned int bitRate)
 {
   this->sSvcParam.iTargetBitrate = bitRate;
   for (int i = 0; i < this->sSvcParam.iSpatialLayerNum; i++)

--- a/Source/VideoStreaming/igtlH264Encoder.h
+++ b/Source/VideoStreaming/igtlH264Encoder.h
@@ -158,7 +158,7 @@ public:
    */
   int SetSpeed(int speed) override;
   
-  int SetRCTaregetBitRate(unsigned int bitRate) override;
+  int SetRCTargetBitRate(unsigned int bitRate) override;
   
   bool GetLosslessLink() override {return this->sSvcParam.bIsLosslessLink;};
   

--- a/Source/VideoStreaming/igtlH265Encoder.cxx
+++ b/Source/VideoStreaming/igtlH265Encoder.cxx
@@ -64,7 +64,7 @@ int H265Encoder::FillSpecificParameters() {
   return 0;
 }
 
-int H265Encoder::SetRCTaregetBitRate(unsigned int bitRate)
+int H265Encoder::SetRCTargetBitRate(unsigned int bitRate)
 {
   this->sSvcParam->rc.aqMode = X265_AQ_VARIANCE;
   this->sSvcParam->rc.rateControlMode = X265_RC_ABR;

--- a/Source/VideoStreaming/igtlH265Encoder.h
+++ b/Source/VideoStreaming/igtlH265Encoder.h
@@ -116,7 +116,7 @@ public:
   
   int SetSpeed(int speed) override;
   
-  int SetRCTaregetBitRate(unsigned int bitRate) override;
+  int SetRCTargetBitRate(unsigned int bitRate) override;
   
   bool GetLosslessLink() override {return this->sSvcParam->bLossless;};
   

--- a/Source/VideoStreaming/igtlVP9Encoder.cxx
+++ b/Source/VideoStreaming/igtlVP9Encoder.cxx
@@ -133,7 +133,7 @@ int VP9Encoder::SetKeyFrameDistance(int frameNum)
 }
 
 
-int VP9Encoder::SetRCTaregetBitRate(unsigned int bitRate)
+int VP9Encoder::SetRCTargetBitRate(unsigned int bitRate)
 {
   // The bit rate in VPX is in Kilo
   int bitRateInKilo = bitRate/1000;

--- a/Source/VideoStreaming/igtlVP9Encoder.h
+++ b/Source/VideoStreaming/igtlVP9Encoder.h
@@ -81,7 +81,7 @@ public:
   
   int SetQP(int maxQP, int minQP) override;
   
-  int SetRCTaregetBitRate(unsigned int bitRate) override;
+  int SetRCTargetBitRate(unsigned int bitRate) override;
   
   int SetLosslessLink(bool linkMethod) override;
   


### PR DESCRIPTION
Target was misspelled as Tareget in several OpenIGTLink classes. This error was recently fixed in OpenIGTLinkIO. Rather than revert to the incorrect spelling in OpenIGTLinkIO, this PR fixes the spelling mistake.